### PR TITLE
Lock rubyzip version to 1.3.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,4 +33,4 @@ dev_gem 'poise-boiler'
 dev_gem 'poise-profiler'
 
 # To make life easier for unit testing.
-gem 'rubyzip'
+gem 'rubyzip', '~> 1.3.0'


### PR DESCRIPTION
 - Prevent updating to 2.0